### PR TITLE
Printing a warning when a browser instance is killed because of maxSu…

### DIFF
--- a/src/core/BrowserLauncher.ts
+++ b/src/core/BrowserLauncher.ts
@@ -260,6 +260,7 @@ export class BrowserLauncher {
 
                 const p: Promise<void>[] = []
                 for (const fb of killThese) {
+                    console.warn('WARNING: Killing a browser instance because maxSurvivalTime was reached.')
                     p.push(fb.shutdown())
                 }
 


### PR DESCRIPTION
…rvivalTime

I think adding a warning when an instance is killed because it ran longer than the maxSurvivalTime would save people some time when debugging, because it's really not obvious to know what killed the process if you don't know the inner working of the library.